### PR TITLE
Use CUTLASS for both `trans_a` and `trans_b` on Ampere

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,26 @@ A lighweight library exposing grouped GEMM kernels in PyTorch.
 # Installation
 
 Run `pip install grouped_gemm` to install the package.
+
+# Compiling from source
+
+By default, the installed package runs in conservative (`cuBLAS`) mode:
+it launches one GEMM kernel per batch element instead of using a single
+grouped GEMM kernel for the whole batch.
+
+To enable using grouped GEMM kernels, you need to switch to the `CUTLASS`
+mode by setting the `GROUPED_GEMM_CUTLASS` environment variable to `1`
+when building the library. For example, to build the library in `CUTLASS`
+mode for Ampere (SM 8.0), clone the repository and run the following:
+
+```bash
+$ TORCH_CUDA_ARCH_LIST=8.0 GROUPED_GEMM_CUTLASS=1 pip install .
+```
+
+See [this comment](https://github.com/tgale96/grouped_gemm/pull/14#issuecomment-2211362572)
+for some performance measurements on A100 and H100.
+
+# Upcoming features
+
+* Running grouped GEMM kernels without GPU<->CPU synchronization points.
+* Hopper-optimized grouped GEMM kernels.

--- a/csrc/grouped_gemm.cu
+++ b/csrc/grouped_gemm.cu
@@ -354,7 +354,7 @@ void GroupedGemm(torch::Tensor a,
   TORCH_CHECK(a.ndimension() == 2);
   TORCH_CHECK(a.scalar_type() == torch::kBFloat16);
 
-#if !defined(GROUPED_GEMM_FULL_CUTLASS)
+#if !defined(GROUPED_GEMM_CUTLASS)
   if (trans_a) {
     // If we can't use CUTLASS for the transposed cases, defer to the variable 'k' helper using cuBLAS
     // for the rest of the op.
@@ -398,13 +398,10 @@ void GroupedGemm(torch::Tensor a,
   TORCH_CHECK(b.is_contiguous());
   TORCH_CHECK(c.is_contiguous());
 
-
-  // NOTE: Use cuBLAS for SM90 until CUTLASS supports SM90-optimized grouped-gemm.
-#if !defined(GROUPED_GEMM_DEVICE_CAPABILITY) || GROUPED_GEMM_DEVICE_CAPABILITY != 80
+#if !defined(GROUPED_GEMM_CUTLASS)
   CublasGroupedGemm(a, b, c, batch_sizes, trans_b);
   return;
 #else
-#if defined(GROUPED_GEMM_FULL_CUTLASS)
   if (trans_a) {
     CutlassGroupedGemm<true, false>(a, b, c, batch_sizes);
     return;
@@ -413,13 +410,6 @@ void GroupedGemm(torch::Tensor a,
     CutlassGroupedGemm<false, true>(a, b, c, batch_sizes);
     return;
   }
-#else
-  TORCH_CHECK(!trans_a, "The trans_a case should have been handled earlier");
-  if (trans_b) {
-    CublasGroupedGemm(a, b, c, batch_sizes, trans_b);
-    return;
-  }
-#endif
   CutlassGroupedGemm<false, false>(a, b, c, batch_sizes);
   return;
 #endif

--- a/csrc/grouped_gemm.cu
+++ b/csrc/grouped_gemm.cu
@@ -99,12 +99,10 @@ torch::Tensor CopyToDevice(const std::vector<T> &x, const torch::Device &device)
 template <typename T>
 static void ReorderArray(T* data, const std::vector<size_t>& indices) {
     // For now, simply create a copy of the data and then copy over to the original.
-    std::vector<T> copy(indices.size());
+    std::vector<T> copy(data, data + indices.size());
     for (size_t i = 0; i < indices.size(); ++i) {
-        copy.at(i) = data[indices[i]];
+        data[i] = copy.at(indices[i]);
     }
-
-    memcpy(data, copy.data(), indices.size() * sizeof(T));
 }
 
 template <typename Gemm, bool trans_a, bool trans_b>

--- a/grouped_gemm/ops_test.py
+++ b/grouped_gemm/ops_test.py
@@ -132,6 +132,21 @@ class EdgeCasesTest(unittest.TestCase):
         self.assertTrue(allclose(a.grad, a_ref.grad))
         self.assertTrue(allclose(b.grad, b_ref.grad))
 
+    def testGroupedGemm_ZeroK(self):
+        sz = 128
+        total_tokens = 192
+
+        a = torch.ones(total_tokens, sz).cuda().to(torch.bfloat16)
+        b = torch.ones(total_tokens, sz).cuda().to(torch.bfloat16)
+        c = torch.ones(4, sz, sz).cuda().to(torch.bfloat16)
+        batch_sizes = torch.tensor([0, 128, 0, 64]).to(torch.long)
+
+        ops.backend.gmm(a, b, batch_sizes, trans_a=True, c=c)
+        self.assertTrue((c[0] == 0).all())
+        self.assertTrue((c[1] == 128).all())
+        self.assertTrue((c[2] == 0).all())
+        self.assertTrue((c[3] == 64).all())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -4,27 +4,14 @@ from setuptools import setup, find_packages
 import torch
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
-if os.environ.get("TORCH_CUDA_ARCH_LIST"):
-    # Let PyTorch builder to choose device to target for.
-    device_capability = ""
-else:
-    device_capability = torch.cuda.get_device_capability()
-    device_capability = f"{device_capability[0]}{device_capability[1]}"
-
 cwd = Path(os.path.dirname(os.path.abspath(__file__)))
 
 nvcc_flags = [
     "-std=c++17",  # NOTE: CUTLASS requires c++17
 ]
 
-if device_capability:
-    nvcc_flags.extend([
-        f"--generate-code=arch=compute_{device_capability},code=sm_{device_capability}",
-        f"-DGROUPED_GEMM_DEVICE_CAPABILITY={device_capability}",
-    ])
-
-if os.environ.get("GROUPED_GEMM_FULL_CUTLASS", "0") == "1":
-    nvcc_flags.extend(["-DGROUPED_GEMM_FULL_CUTLASS"])
+if os.environ.get("GROUPED_GEMM_CUTLASS", "0") == "1":
+    nvcc_flags.extend(["-DGROUPED_GEMM_CUTLASS"])
 
 ext_modules = [
     CUDAExtension(

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ if device_capability:
         f"-DGROUPED_GEMM_DEVICE_CAPABILITY={device_capability}",
     ])
 
+if os.environ.get("GROUPED_GEMM_FULL_CUTLASS", "0") == "1":
+    nvcc_flags.extend(["-DGROUPED_GEMM_FULL_CUTLASS"])
+
 ext_modules = [
     CUDAExtension(
         "grouped_gemm_backend",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ extra_deps['all'] = set(dep for deps in extra_deps.values() for dep in deps)
 
 setup(
     name="grouped_gemm",
-    version="0.1.4",
+    version="0.1.5",
     author="Trevor Gale",
     author_email="tgale@stanford.edu",
     description="Grouped GEMM",

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,23 @@ from setuptools import setup, find_packages
 import torch
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
+if os.environ.get("TORCH_CUDA_ARCH_LIST"):
+    # Let PyTorch builder to choose device to target for.
+    device_capability = ""
+else:
+    device_capability = torch.cuda.get_device_capability()
+    device_capability = f"{device_capability[0]}{device_capability[1]}"
+
 cwd = Path(os.path.dirname(os.path.abspath(__file__)))
 
 nvcc_flags = [
     "-std=c++17",  # NOTE: CUTLASS requires c++17
 ]
+
+if device_capability:
+    nvcc_flags.extend([
+        f"--generate-code=arch=compute_{device_capability},code=sm_{device_capability}",
+    ])
 
 if os.environ.get("GROUPED_GEMM_CUTLASS", "0") == "1":
     nvcc_flags.extend(["-DGROUPED_GEMM_CUTLASS"])


### PR DESCRIPTION
~~**Note that this PR *can't* be merged as is; see the end of the description.**~~ I implemented a workaround, so this PR should be safe to merge.

This PR is based on imoneoi@'s awesome work [here](https://github.com/tgale96/grouped_gemm/pull/6). The problem sorting code (which is only [needed](https://github.com/NVIDIA/cutlass/blob/main/media/docs/grouped_scheduler.md#potential-for-sorting-problems-to-reduce-imbalance) for variable-size `k`, i.e., in the backward pass) was copied from their PR verbatim. Everything else is structured pretty much the same conceptually, the only difference is that I tried to make the changes very minimal. Notably:
  * the original PR got rid of hardcoded threadblock/warp/instruction shapes, I left them as is (they can be changed in a separate PR, if necessary)
  * the original PR got rid of the cuBLAS fallback for Hopper, I left it intact (I think that it should be easy to make Hopper use CUTLASS too, but again, this can be done in a separate PR)

The only caveat is that vanilla CUTLASS has a bug I [described previously](https://github.com/tgale96/grouped_gemm/pull/6#issuecomment-2179455300) when handling `k=0` in a grouped GEMM. I added a test that reliably crashes the backward pass with a `CUDA error: an illegal memory access was encountered` error. The dimensions of the GEMM are larger than what is used in the other tests, but making them smaller unfortunately makes the crash go away, since the bug leads to an OOB read, which can go undetected without using `compute-sanitizer`.

I'm currently not sure how to work around this. The best option would be upstream CUTLASS landing my PR fixing the bug (and/or implementing an alternative fix), but I'm really not sure when this will happen. Looking at their opened PRs, I see that it might take weeks, or even months for a PR to be merged. :/