### PR TITLE
Add `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+# build requirements
+[build-system]
+requires = ["setuptools < 70.0.0", "packaging >= 21.0.0", "torch >= 2.3.0, < 2.4"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -68,4 +68,3 @@ setup(
     cmdclass={"build_ext": BuildExtension},
     extras_require=extra_deps,
 )
-)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 import os
 from pathlib import Path
-from setuptools import setup, find_packages
+
 import torch
+from setuptools import find_packages, setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 if os.environ.get("TORCH_CUDA_ARCH_LIST"):
@@ -40,8 +41,6 @@ ext_modules = [
     )
 ]
 
-install_requires = ['torch>=2.3.0,<2.4',]
-
 extra_deps = {}
 
 extra_deps['dev'] = [
@@ -67,6 +66,6 @@ setup(
     packages=find_packages(),
     ext_modules=ext_modules,
     cmdclass={"build_ext": BuildExtension},
-    install_requires=install_requires,
     extras_require=extra_deps,
+)
 )

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ ext_modules = [
     )
 ]
 
+install_requires = ['torch>=2.3.0,<2.4',]
+
 extra_deps = {}
 
 extra_deps['dev'] = [
@@ -65,5 +67,6 @@ setup(
     packages=find_packages(),
     ext_modules=ext_modules,
     cmdclass={"build_ext": BuildExtension},
+    install_requires=install_requires,
     extras_require=extra_deps,
 )


### PR DESCRIPTION
This PR adds a `pyproject.toml` to the grouped_gemm project.

Including `torch` as a requirement in the `pyproject.toml` resolves some issues where the computer thinks torch is installed even though it is not. 

This is bug arose in the context of adding a `pyproject.toml` to MegaBlocks.