### PR TITLE
Support GPU-resident batch sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,4 @@ for some performance measurements on A100 and H100.
 
 # Upcoming features
 
-* Running grouped GEMM kernels without GPU<->CPU synchronization points.
 * Hopper-optimized grouped GEMM kernels.

--- a/csrc/fill_arguments.cuh
+++ b/csrc/fill_arguments.cuh
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <ATen/cuda/detail/KernelUtils.h>
+#include <cub/cub.cuh>
+#include <cutlass/bfloat16.h>
+#include <cutlass/gemm_coord.h>
+
+namespace grouped_gemm {
+
+constexpr int kDynamicDim = -1;
+constexpr int kMaxExperts = 512;
+
+struct GemmProblem {
+  ::cutlass::gemm::GemmCoord dims;
+  int64_t lda, ldb, ldc;
+  // All offsets are in elements.
+  int64_t a_offset, b_offset, c_offset;
+};
+
+struct ExtractGemmProblemK {
+  __device__ ::cuda::std::tuple<int&> operator()(GemmProblem& problem) const {
+      return {problem.dims.k()};
+  }
+};
+
+template <
+    // If `k` is dynamic, we sort the problems by `k` in descending order.
+    // Otherwise, `m` is dynamic, and no sorting happens.
+    bool dynamic_k,
+    typename ElementA, typename ElementB, typename ElementC,
+    typename LayoutA, typename LayoutB, typename LayoutC,
+    typename Args
+>
+__global__ void FillArguments(
+    int num_experts, const int64_t* batch_sizes,
+    ElementA* ptr_a, ElementB* ptr_b, ElementC* ptr_c,
+    Args args, ::cutlass::gemm::GemmCoord dims
+) {
+  const int expert_idx = threadIdx.x;
+  const int batch_size = expert_idx < num_experts ? batch_sizes[expert_idx] : -1;
+
+  if (dynamic_k) {
+    assert(dims.k() == kDynamicDim);
+    dims.k() = batch_size;
+  } else {
+    assert(dims.m() == kDynamicDim);
+    dims.m() = batch_size;
+  }
+
+  using BlockScan = cub::BlockScan<int, kMaxExperts>;
+  using BlockSort = cub::BlockRadixSort<GemmProblem, kMaxExperts, 1>;
+
+  union SharedMemory {
+    BlockScan::TempStorage scan_storage;
+    BlockSort::TempStorage sort_storage;
+  };
+  __shared__ SharedMemory shared_memory;
+
+  int dynamic_dim = dynamic_k ? dims.k() : dims.m();
+  int dynamic_dim_cumsum;
+  BlockScan(shared_memory.scan_storage).ExclusiveSum(dynamic_dim, dynamic_dim_cumsum);
+  __syncthreads();
+
+  GemmProblem problem[1] = {
+    GemmProblem {
+      .dims = dims,
+      .lda = LayoutA::packed({dims.m(), dims.k()}).stride(0),
+      .ldb = LayoutB::packed({dims.k(), dims.n()}).stride(0),
+      .ldc = LayoutC::packed({dims.m(), dims.n()}).stride(0),
+      .a_offset = dynamic_k
+          ? (dims.m() * dynamic_dim_cumsum)
+          : (dynamic_dim_cumsum * dims.k()),
+      .b_offset = (dynamic_k ? dynamic_dim_cumsum : expert_idx * dims.k()) * dims.n(),
+      .c_offset = (dynamic_k ? expert_idx * dims.m() : dynamic_dim_cumsum) * dims.n(),
+    },
+  };
+
+  if constexpr (dynamic_k) {
+    BlockSort(shared_memory.sort_storage).SortDescending(problem, ExtractGemmProblemK{});
+    // Quoting the CUB documentation (https://nvidia.github.io/cccl/cub/api/classcub_1_1BlockRadixSort.html):
+    // > A subsequent __syncthreads() threadblock barrier should be invoked after calling this method if the collective’s temporary storage [...]
+    // > is **to be reused or repurposed**.
+    // We don't need `__syncthreads()` here, since we don't do either of these things.
+  }
+
+  if (expert_idx < num_experts) {
+    args.problem_sizes[expert_idx] = problem[0].dims;
+    args.lda[expert_idx] = problem[0].lda;
+    args.ldb[expert_idx] = problem[0].ldb;
+    args.ldc[expert_idx] = problem[0].ldc;
+
+    args.ptr_A[expert_idx] = ptr_a + problem[0].a_offset;
+    args.ptr_B[expert_idx] = ptr_b + problem[0].b_offset;
+    args.ptr_C[expert_idx] = ptr_c + problem[0].c_offset;
+  }
+}
+
+template <typename Args>
+__global__ void ZeroOutK0Outputs(int num_experts, Args args) {
+  const int64_t start_idx = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+  const int64_t delta     = (int64_t)gridDim.x * blockDim.x;
+  for (int ei = 0; ei < num_experts; ++ei) {
+    auto& dims = args.problem_sizes[ei];
+    // CUTLASS doesn't handle problems with `k=0` correctly, see https://github.com/NVIDIA/cutlass/pull/1593.
+    // Until a fix is available on the CUTLASS side, handle these problems by ourselves:
+    //   * (here) set the output to zero
+    //   * (in `IgnoreK0Problems`) make this problem a no-op by setting `m=0` and `n=0` (CUTLASS can handle the outer dimensions being zero)
+    if (dims.k() == 0) {
+      // Assume packed layout, run a grid-strided loop over the output.
+      int64_t total_elems = (int64_t)dims.m() * dims.n();
+      auto* out           = args.ptr_C[ei];
+      for (int64_t idx = start_idx; idx < total_elems; idx += delta) {
+        out[idx] = {};
+      }
+    }
+  }
+}
+
+template <typename Args>
+__global__ void IgnoreK0Problems(int num_experts, Args args) {
+  const int expert_idx = threadIdx.x;
+  if (expert_idx < num_experts) {
+    auto& dims = args.problem_sizes[expert_idx];
+    if (dims.k() == 0) {
+      dims.m() = 0;
+      dims.n() = 0;
+    }
+  }
+}
+
+}  // namespace grouped_gemm

--- a/csrc/fill_arguments.cuh
+++ b/csrc/fill_arguments.cuh
@@ -61,6 +61,8 @@ __global__ void FillArguments(
   BlockScan(shared_memory.scan_storage).ExclusiveSum(dynamic_dim, dynamic_dim_cumsum);
   __syncthreads();
 
+  // We have to use `GemmProblem[1]` here instead of just `GemmProblem` because `SortDescending()` expects
+  // `KeyT (&)[ITEMS_PER_THREAD]` for the `keys` argument (i.e., `GemmProblem (&keys)[1]` in our case).
   GemmProblem problem[1] = {
     GemmProblem {
       .dims = dims,

--- a/csrc/grouped_gemm.cu
+++ b/csrc/grouped_gemm.cu
@@ -518,6 +518,10 @@ void GroupedGemm(torch::Tensor a,
   CublasGroupedGemm(a, b, c, batch_sizes, trans_b);
   return;
 #else
+  // The `coord_template` argument contains `kDynamicDim` as one of its dimensions
+  // as a placeholder. This placeholder is later expanded into the actual dimension
+  // for every element of the batch,  either on the host or on the device
+  // (if we can't do in on the host).
   const auto coord_template = trans_a
     ? cutlass::gemm::GemmCoord(hidden_in, hidden_out, kDynamicDim)
     : cutlass::gemm::GemmCoord(kDynamicDim, hidden_out, hidden_in);

--- a/csrc/grouped_gemm.cu
+++ b/csrc/grouped_gemm.cu
@@ -216,6 +216,10 @@ typename Gemm::Arguments MakeArguments(torch::Tensor a,
   }
 
   typename Gemm::EpilogueOutputOp::Params epilogue_op(/*alpha=*/1.0f, /*beta=*/0.0f);
+  // We currently always use `GroupScheduleMode::kDeviceOnly`, which doesn't use `host_problem_sizes` at all,
+  // so we can safely pass `nullptr` for `host_problem_sizes`.
+  // TODO(tgale): Experiment with `GroupScheduleMode::kHostPrecompute` for `batch_sizes.is_cpu()`, where we
+  // know the problem dimensions on the host.
   typename Gemm::Arguments arguments((cutlass::gemm::GemmCoord*)problem_sizes.data_ptr(),
   				     (int)num_experts,
   				     (int)threadblock_count,
@@ -228,12 +232,6 @@ typename Gemm::Arguments MakeArguments(torch::Tensor a,
   				     /*ldb=*/(int64_t*)ldb.data_ptr(),
   				     /*ldc=*/(int64_t*)ldc.data_ptr(),
   				     /*ldd=*/(int64_t*)ldc.data_ptr(),
-  				     // We currently always use `GroupScheduleMode::kDeviceOnly`,
-  				     // which doesn't use `host_problem_sizes` at all, so we can
-  				     // safely pass `nullptr` here.
-  				     // TODO(tgale): Experiment with `GroupScheduleMode::kHostPrecompute`
-  				     // for `batch_sizes.is_cpu()`, where we know the problem dimensions
-  				     // on the host.
   				     /*host_problem_sizes=*/nullptr);
   return arguments;
 }

--- a/csrc/grouped_gemm.cu
+++ b/csrc/grouped_gemm.cu
@@ -1,8 +1,11 @@
 #include "grouped_gemm.h"
+#include "fill_arguments.cuh"
 
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/detail/KernelUtils.h>
 #include <c10/util/BFloat16.h>
 #include <c10/cuda/CUDAStream.h>
+#include <cub/cub.cuh>
 #include <torch/extension.h>
 
 #include "cutlass/bfloat16.h"
@@ -71,26 +74,11 @@ using GroupedGemmKernel = typename cutlass::gemm::kernel::DefaultGemmGrouped<
   // This parameter is passed in at present to match the APIs of other kernels. The parameter
   // is unused within the kernel.
   ::cutlass::gemm::threadblock::GemmBatchedIdentityThreadblockSwizzle,
-  // TODO(tgale): Experiment with GroupScheduleMode.
   // TODO(tgale): Tune this for SM90.
   GroupedGemmConfig::kStages>::GemmKernel;
 
 template <bool trans_a, bool trans_b>
 using GemmGrouped = ::cutlass::gemm::device::GemmGrouped<GroupedGemmKernel<trans_a, trans_b>>;
-
-template <bool trans_a, bool trans_b>
-std::vector<cutlass::gemm::GemmCoord> MakeProblemSizes(torch::Tensor a, torch::Tensor b, torch::Tensor batch_sizes) {
-  const size_t num_experts = batch_sizes.size(0);
-  const size_t hidden_in = a.size(1), hidden_out = (trans_a || trans_b) ? b.size(1) : b.size(2);
-  std::vector<cutlass::gemm::GemmCoord> problem_sizes(num_experts);
-  for (int i = 0; i < num_experts; ++i) {
-    int64_t bs = batch_sizes.data_ptr<int64_t>()[i];
-    problem_sizes[i] = trans_a
-      ? cutlass::gemm::GemmCoord(hidden_in, hidden_out, bs)
-      : cutlass::gemm::GemmCoord(bs, hidden_out, hidden_in);
-  }
-  return problem_sizes;
-}
 
 template <typename T>
 torch::Tensor CopyToDevice(const std::vector<T> &x, const torch::Device &device) {
@@ -114,96 +102,118 @@ static void ReorderArray(T* data, const std::vector<size_t>& indices) {
     }
 }
 
-template <typename Gemm, bool trans_a, bool trans_b>
+template <typename T>
+torch::Tensor TypedEmpty(size_t numel, const torch::Device& device) {
+    return torch::empty(numel * sizeof(T), torch::dtype(torch::kInt8).device(device));
+}
+
+template <
+  bool dynamic_k,
+  typename Gemm,
+  typename ElementA, typename ElementB, typename ElementC,
+  typename LayoutA, typename LayoutB, typename LayoutC
+>
 typename Gemm::Arguments MakeArguments(torch::Tensor a,
 				       torch::Tensor b,
 				       torch::Tensor c,
-				       torch::Tensor batch_sizes) {
-  auto problem_sizes_host = MakeProblemSizes<trans_a, trans_b>(a, b, batch_sizes);
+				       torch::Tensor batch_sizes,
+				       ::cutlass::gemm::GemmCoord coord_template,
+				       int64_t num_experts) {
+  torch::Tensor lda, ldb, ldc, ptr_a, ptr_b, ptr_c, problem_sizes;
+  int threadblock_count{};
 
-  int64_t num_experts_orig = problem_sizes_host.size();
+  if (batch_sizes.is_cuda()) {
+    TORCH_CHECK(
+        num_experts <= kMaxExperts,
+        "At most ", kMaxExperts,
+        " experts are supported when batch_sizes is a CUDA tensor, but got ", num_experts
+    );
 
-  // Create the host arrays of leading dimension data and pointer data.
-  using LayoutA = typename Gemm::LayoutA;
-  using LayoutB = typename Gemm::LayoutB;
-  using LayoutC = typename Gemm::LayoutC;
+    lda = TypedEmpty<int64_t>(num_experts, a.device());
+    ldb = TypedEmpty<int64_t>(num_experts, a.device());
+    ldc = TypedEmpty<int64_t>(num_experts, a.device());
+    ptr_a = TypedEmpty<ElementA*>(num_experts, a.device());
+    ptr_b = TypedEmpty<ElementB*>(num_experts, a.device());
+    ptr_c = TypedEmpty<ElementC*>(num_experts, a.device());
+    problem_sizes = TypedEmpty<cutlass::gemm::GemmCoord>(num_experts, a.device());
 
-  std::vector<int64_t> lda_host, ldb_host, ldc_host;
-  int64_t elements_a = 0, elements_b = 0, elements_c = 0;
+    // We don't know the problem dimensions on the host, so we just base the number of threadblocks on occupancy here.
+    threadblock_count = Gemm::sufficient();
+  } else {
+    std::vector<::cutlass::gemm::GemmCoord> problem_sizes_host(num_experts);
 
-  using ElementA = typename Gemm::ElementA;
-  using ElementB = typename Gemm::ElementB;
-  using ElementC = typename Gemm::ElementC;
-  std::vector<ElementA *> ptr_a_host, ptr_b_host, ptr_c_host;
+    // Create the host arrays of leading dimension data and pointer data.
+    std::vector<int64_t> lda_host(num_experts), ldb_host(num_experts), ldc_host(num_experts);
+    int64_t elements_a = 0, elements_b = 0, elements_c = 0;
 
-  lda_host.reserve(num_experts_orig);
-  ldb_host.reserve(num_experts_orig);
-  ldc_host.reserve(num_experts_orig);
+    std::vector<ElementA *> ptr_a_host(num_experts), ptr_b_host(num_experts), ptr_c_host(num_experts);
 
-  ptr_a_host.reserve(num_experts_orig);
-  ptr_b_host.reserve(num_experts_orig);
-  ptr_c_host.reserve(num_experts_orig);
+    for (int i = 0; i < num_experts; ++i) {
+      auto& problem = problem_sizes_host[i];
+      problem = coord_template;
+      (dynamic_k ? problem.k() : problem.m()) = batch_sizes.data_ptr<int64_t>()[i];
 
-  // CUTLASS doesn't handle problems with `k=0` correctly, see https://github.com/NVIDIA/cutlass/pull/1593.
-  // Until a fix is available on the CUTLASS side, handle these problems by ourselves.
-  int64_t num_experts = 0;
-  for (int i = 0; i < num_experts_orig; ++i) {
-    auto problem = problem_sizes_host[i];
-    if (problem.k() == 0) {
-      CUDA_CALL(cudaMemsetAsync((ElementC*)c.data_ptr() + elements_c,
-				0,
-				problem.m() * problem.n() * sizeof(ElementC),
-				c10::cuda::getCurrentCUDAStream()));
-    } else {
-      lda_host.push_back(LayoutA::packed({problem.m(), problem.k()}).stride(0));
-      ldb_host.push_back(LayoutB::packed({problem.k(), problem.n()}).stride(0));
-      ldc_host.push_back(LayoutC::packed({problem.m(), problem.n()}).stride(0));
+      lda_host[i] = LayoutA::packed({problem.m(), problem.k()}).stride(0);
+      ldb_host[i] = LayoutB::packed({problem.k(), problem.n()}).stride(0);
+      ldc_host[i] = LayoutC::packed({problem.m(), problem.n()}).stride(0);
 
-      ptr_a_host.push_back((ElementA*)a.data_ptr() + elements_a);
-      ptr_b_host.push_back((ElementB*)b.data_ptr() + elements_b);
-      ptr_c_host.push_back((ElementC*)c.data_ptr() + elements_c);
+      ptr_a_host[i] = (ElementA*)a.data_ptr() + elements_a;
+      ptr_b_host[i] = (ElementB*)b.data_ptr() + elements_b;
+      ptr_c_host[i] = (ElementC*)c.data_ptr() + elements_c;
 
-      problem_sizes_host[num_experts++] = problem;
+      elements_a += problem.m() * problem.k();
+      elements_b += problem.k() * problem.n();
+      elements_c += problem.m() * problem.n();
+
+      if (problem.k() == 0) {
+        // CUTLASS doesn't handle problems with `k=0` correctly, see https://github.com/NVIDIA/cutlass/pull/1593.
+        // Until a fix is available on the CUTLASS side, handle these problems by ourselves:
+        //   * set the output to zero with `cudaMemsetAsync()`
+        //   * make this problem a no-op by setting `m=0` and `n=0` (CUTLASS can handle the outer dimensions being zero)
+        CUDA_CALL(cudaMemsetAsync(ptr_c_host[i],
+          0,
+          problem.m() * problem.n() * sizeof(ElementC),
+          c10::cuda::getCurrentCUDAStream()));
+
+        problem.m() = 0;
+        problem.n() = 0;
+      }
     }
 
-    elements_a += problem.m() * problem.k();
-    elements_b += problem.k() * problem.n();
-    elements_c += problem.m() * problem.n();
-  }
-  problem_sizes_host.resize(num_experts);
+    // We know the problem dimensions on the host, so we can calculate the number of threadblocks based on that.
+    threadblock_count = Gemm::sufficient(problem_sizes_host.data(), num_experts);
 
-  // Calculate the number of threadblocks to use and validate the result.
-  // NOTE: This is borrowed from FasterTransformer.
-  int threadblock_count = Gemm::sufficient(problem_sizes_host.data(), num_experts);
+    // Only sort problems when K are different
+    if (dynamic_k) {
+        std::vector<size_t> indices(num_experts);
+        std::iota(indices.begin(), indices.end(), 0);
+        std::stable_sort(indices.begin(), indices.end(), [&problem_sizes_host](size_t i, size_t j) {
+            return problem_sizes_host[i].k() > problem_sizes_host[j].k();
+        });
+
+        ReorderArray(problem_sizes_host.data(), indices);
+        ReorderArray(lda_host.data(), indices);
+        ReorderArray(ldb_host.data(), indices);
+        ReorderArray(ldc_host.data(), indices);
+        ReorderArray(ptr_a_host.data(), indices);
+        ReorderArray(ptr_b_host.data(), indices);
+        ReorderArray(ptr_c_host.data(), indices);
+    }
+
+    // Copy the problem sizes, pointers and leading dimension data to the device.
+    lda = CopyToDevice(lda_host, a.device());
+    ldb = CopyToDevice(ldb_host, a.device());
+    ldc = CopyToDevice(ldc_host, a.device());
+    ptr_a = CopyToDevice(ptr_a_host, a.device());
+    ptr_b = CopyToDevice(ptr_b_host, a.device());
+    ptr_c = CopyToDevice(ptr_c_host, a.device());
+    problem_sizes = CopyToDevice(problem_sizes_host, a.device());
+  }
+
+  // Validate the result.
   if (!threadblock_count) {
     TORCH_CHECK(false, "Grouped GEMM execution not possible with HW");
   }
-
-  // Only sort problems when trans_a = True because only this case K are different
-  if (trans_a) {
-      std::vector<size_t> indices(num_experts);
-      std::iota(indices.begin(), indices.end(), 0);
-      std::stable_sort(indices.begin(), indices.end(), [&problem_sizes_host](size_t i, size_t j) {
-          return problem_sizes_host[i].k() > problem_sizes_host[j].k();
-      });
-
-      ReorderArray(problem_sizes_host.data(), indices);
-      ReorderArray(lda_host.data(), indices);
-      ReorderArray(ldb_host.data(), indices);
-      ReorderArray(ldc_host.data(), indices);
-      ReorderArray(ptr_a_host.data(), indices);
-      ReorderArray(ptr_b_host.data(), indices);
-      ReorderArray(ptr_c_host.data(), indices);
-  }
-
-  // Copy the problem sizes, pointers and leading dimension data to the device.
-  torch::Tensor lda = CopyToDevice(lda_host, a.device());
-  torch::Tensor ldb = CopyToDevice(ldb_host, a.device());
-  torch::Tensor ldc = CopyToDevice(ldc_host, a.device());
-  torch::Tensor ptr_a = CopyToDevice(ptr_a_host, a.device());
-  torch::Tensor ptr_b = CopyToDevice(ptr_b_host, a.device());
-  torch::Tensor ptr_c = CopyToDevice(ptr_c_host, a.device());
-  torch::Tensor problem_sizes = CopyToDevice(problem_sizes_host, a.device());
 
   typename Gemm::EpilogueOutputOp::Params epilogue_op(/*alpha=*/1.0f, /*beta=*/0.0f);
   typename Gemm::Arguments arguments((cutlass::gemm::GemmCoord*)problem_sizes.data_ptr(),
@@ -218,7 +228,13 @@ typename Gemm::Arguments MakeArguments(torch::Tensor a,
   				     /*ldb=*/(int64_t*)ldb.data_ptr(),
   				     /*ldc=*/(int64_t*)ldc.data_ptr(),
   				     /*ldd=*/(int64_t*)ldc.data_ptr(),
-  				     (cutlass::gemm::GemmCoord*)problem_sizes_host.data());
+  				     // We currently always use `GroupScheduleMode::kDeviceOnly`,
+  				     // which doesn't use `host_problem_sizes` at all, so we can
+  				     // safely pass `nullptr` here.
+  				     // TODO(tgale): Experiment with `GroupScheduleMode::kHostPrecompute`
+  				     // for `batch_sizes.is_cpu()`, where we know the problem dimensions
+  				     // on the host.
+  				     /*host_problem_sizes=*/nullptr);
   return arguments;
 }
 
@@ -226,14 +242,61 @@ template <bool trans_a, bool trans_b>
 torch::Tensor CutlassGroupedGemm(torch::Tensor a,
 				 torch::Tensor b,
 				 torch::Tensor c,
-				 torch::Tensor batch_sizes) {
+				 torch::Tensor batch_sizes,
+				 ::cutlass::gemm::GemmCoord coord_template) {
   using Gemm = GemmGrouped<trans_a, trans_b>;
-  Gemm gemm;
+  using LayoutA = typename Gemm::LayoutA;
+  using LayoutB = typename Gemm::LayoutB;
+  using LayoutC = typename Gemm::LayoutC;
 
-  auto arguments = MakeArguments<Gemm, trans_a, trans_b>(a, b, c, batch_sizes);
+  using ElementA = typename Gemm::ElementA;
+  using ElementB = typename Gemm::ElementB;
+  using ElementC = typename Gemm::ElementC;
+
+  Gemm gemm;
+  int64_t num_experts = batch_sizes.size(0);
+  auto arguments = MakeArguments<
+    /*dynamic_k*/trans_a,
+    Gemm,
+    ElementA, ElementB, ElementC,
+    LayoutA, LayoutB, LayoutC
+  >(a, b, c, batch_sizes, coord_template, num_experts);
   int64_t workspace_size = gemm.get_workspace_size(arguments);
   auto options = torch::TensorOptions().dtype(torch::kInt8).device(a.device());
   torch::Tensor workspace = torch::empty(workspace_size, options);
+
+  if (batch_sizes.is_cuda()) {
+      // Convert the batch sizes to the format CUTLASS understands on the device.
+      // Use a single block here because:
+      //   * the number of elements to process is microscopically small
+      //   * we don't need any additional global memory
+      FillArguments<
+          /*dynamic_k*/trans_a,
+          ElementA, ElementB, ElementC,
+          LayoutA, LayoutB, LayoutC
+      ><<<1, kMaxExperts, 0, c10::cuda::getCurrentCUDAStream()>>>(
+          num_experts, batch_sizes.data_ptr<int64_t>(),
+          (ElementA*)a.data_ptr(), (ElementB*)b.data_ptr(), (ElementC*)c.data_ptr(),
+          arguments, coord_template
+      );
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+      // For zeroing out the outputs (which might be arbitrarily large), we want to use
+      // as many threadblocks as possible in order to hit the maximum possible global memory bandwidth.
+      // `arguments.threadblock_count`, which we will use for the grouped GEMM proper,
+      // should be a good approximation for this.
+      // When the `k=0` case is fixed in CUTLASS, we can completely remove the kernel invocations below.
+      ZeroOutK0Outputs<><<<
+        arguments.threadblock_count, at::cuda::detail::CUDA_NUM_THREADS, 0, c10::cuda::getCurrentCUDAStream()
+      >>>(
+        num_experts, arguments
+      );
+      IgnoreK0Problems<><<<
+        1, kMaxExperts, 0, c10::cuda::getCurrentCUDAStream()
+      >>>(
+        num_experts, arguments
+      );
+  }
 
   // Initialize the kernel.
   if(gemm.initialize(arguments, workspace.data_ptr()) != cutlass::Status::kSuccess) {
@@ -352,8 +415,13 @@ void GroupedGemm(torch::Tensor a,
   // NOTE: We only support 'trans_a' or 'trans_b', not both.
   TORCH_CHECK(!(trans_a && trans_b));
 
-  // We expect the batch_sizes on CPU.
+#if !defined(GROUPED_GEMM_CUTLASS)
+  // No way to run cuBLAS kernels if the problem dimensions are not known on the host.
   TORCH_CHECK(batch_sizes.is_cpu());
+#else
+  // CUTLASS can handle both CPU- and CUDA-resident problem dimensions.
+  TORCH_CHECK(batch_sizes.is_cuda() || batch_sizes.is_cpu());
+#endif
   TORCH_CHECK(batch_sizes.ndimension() == 1);
   TORCH_CHECK(batch_sizes.scalar_type() == torch::kInt64);
 
@@ -381,21 +449,25 @@ void GroupedGemm(torch::Tensor a,
   //   * when 'trans_a' is set: b=(tokens, hidden_out),                 c=(num_experts, hidden_in, hidden_out)
   //   * when 'trans_b' is set: b=(num_experts, hidden_out, hidden_in), c=(tokens, hidden_out)
   //   * otherwise:             b=(num_experts, hidden_in, hidden_out), c=(tokens, hidden
+  size_t hidden_in{}, hidden_out{};
   if (trans_a) {
+    hidden_in = a.size(1);
+    hidden_out = b.size(1);
+
     TORCH_CHECK(b.ndimension() == 2);
     TORCH_CHECK(c.ndimension() == 3);
     TORCH_CHECK(b.size(0) == a.size(0));
     TORCH_CHECK(c.size(0) == batch_sizes.size(0));
-    TORCH_CHECK(c.size(1) == a.size(1));
-    TORCH_CHECK(c.size(2) == b.size(1));
+    TORCH_CHECK(c.size(1) == hidden_in);
+    TORCH_CHECK(c.size(2) == hidden_out);
   } else {
     TORCH_CHECK(b.ndimension() == 3);
     TORCH_CHECK(c.ndimension() == 2);
 
     // Validate the contraction dimensions match.
     int64_t tokens = a.size(0), num_experts = b.size(0);
-    int64_t hidden_in = trans_b ? b.size(2) : b.size(1);
-    int64_t hidden_out = trans_b ? b.size(1) : b.size(2);
+    hidden_in = trans_b ? b.size(2) : b.size(1);
+    hidden_out = trans_b ? b.size(1) : b.size(2);
     TORCH_CHECK(hidden_in == a.size(1));
 
     // Validate that we have one size per expert.
@@ -411,15 +483,18 @@ void GroupedGemm(torch::Tensor a,
   CublasGroupedGemm(a, b, c, batch_sizes, trans_b);
   return;
 #else
+  const auto coord_template = trans_a
+    ? cutlass::gemm::GemmCoord(hidden_in, hidden_out, kDynamicDim)
+    : cutlass::gemm::GemmCoord(kDynamicDim, hidden_out, hidden_in);
   if (trans_a) {
-    CutlassGroupedGemm<true, false>(a, b, c, batch_sizes);
+    CutlassGroupedGemm<true, false>(a, b, c, batch_sizes, coord_template);
     return;
   }
   if (trans_b) {
-    CutlassGroupedGemm<false, true>(a, b, c, batch_sizes);
+    CutlassGroupedGemm<false, true>(a, b, c, batch_sizes, coord_template);
     return;
   }
-  CutlassGroupedGemm<false, false>(a, b, c, batch_sizes);
+  CutlassGroupedGemm<false, false>(a, b, c, batch_sizes, coord_template);
   return;
 #endif
 }

--- a/grouped_gemm/ops_test.py
+++ b/grouped_gemm/ops_test.py
@@ -17,15 +17,16 @@ def allclose(x, y, pct=2.0):
     return True
 
 
-def add_transpose_flags(x):
+def add_flags(x):
     out = []
     for y in x:
-        for f in [(False,), (True,)]:
-            out.append(y + f)
+        for trans_b in (False, True):
+            for gpu_batch_sizes in (False, True):
+                out.append(y + (trans_b, gpu_batch_sizes))
     return out
 
 
-_TEST_PROBLEMS = add_transpose_flags((
+_TEST_PROBLEMS = add_flags((
     (1, 128, 128, 128),
     (8, 128, 128, 128),
     (16, 128, 128, 128),
@@ -41,7 +42,7 @@ def randn(bs, x, y):
 
 
 def gmm(a, b, batch_sizes, trans_b=False):
-    batch_sizes = batch_sizes.numpy()
+    batch_sizes = batch_sizes.cpu().numpy()
 
     out = []
     start = 0
@@ -55,11 +56,13 @@ def gmm(a, b, batch_sizes, trans_b=False):
 @parameterized.parameters(*_TEST_PROBLEMS)
 class OpsTest(parameterized.TestCase):
 
-    def testGroupedGemm_FixedSizes(self, z, m, k, n, trans_b):
+    def testGroupedGemm_FixedSizes(self, z, m, k, n, trans_b, gpu_batch_sizes):
         torch.manual_seed(0)
         a = randn(z, m, k).view(-1, k)
         b = randn(z, n, k) if trans_b else randn(z, k, n)
         batch_sizes = torch.tensor([m] * z)
+        if gpu_batch_sizes:
+            batch_sizes = batch_sizes.cuda()
 
         a.requires_grad_(True)
         b.requires_grad_(True)
@@ -76,7 +79,7 @@ class OpsTest(parameterized.TestCase):
         self.assertTrue(allclose(a.grad, a_ref.grad))
         self.assertTrue(allclose(b.grad, b_ref.grad))
 
-    def testGroupedGemm_VariableSizes(self, z, m, k, n, trans_b):
+    def testGroupedGemm_VariableSizes(self, z, m, k, n, trans_b, gpu_batch_sizes):
         torch.manual_seed(0)
         a = randn(z, m, k).view(-1, k)
         b = randn(z, n, k) if trans_b else randn(z, k, n)
@@ -87,6 +90,8 @@ class OpsTest(parameterized.TestCase):
         error = m * z - batch_sizes.sum()
         batch_sizes[-1] += error
         assert batch_sizes.sum() == (m * z)
+        if gpu_batch_sizes:
+            batch_sizes = batch_sizes.cuda()
 
         a.requires_grad_(True)
         b.requires_grad_(True)
@@ -104,9 +109,10 @@ class OpsTest(parameterized.TestCase):
         self.assertTrue(allclose(b.grad, b_ref.grad))
 
 
+@parameterized.parameters(False, True)
 class EdgeCasesTest(unittest.TestCase):
 
-    def testGroupedGemm_ZeroSize(self):
+    def testGroupedGemm_ZeroSize(self, gpu_batch_sizes):
         torch.manual_seed(0)
         m = 16384
         k = 4096
@@ -116,6 +122,8 @@ class EdgeCasesTest(unittest.TestCase):
         a = randn(num_experts, m // num_experts, k).view(-1, k)
         b = randn(num_experts, k, n)
         batch_sizes = torch.tensor([219, 2246, 5, 8103, 1, 1117, 4693, 0]).to(torch.long)
+        if gpu_batch_sizes:
+            batch_sizes = batch_sizes.cuda()
 
         a.requires_grad_(True)
         b.requires_grad_(True)
@@ -132,7 +140,7 @@ class EdgeCasesTest(unittest.TestCase):
         self.assertTrue(allclose(a.grad, a_ref.grad))
         self.assertTrue(allclose(b.grad, b_ref.grad))
 
-    def testGroupedGemm_ZeroK(self):
+    def testGroupedGemm_ZeroK(self, gpu_batch_sizes):
         sz = 128
         total_tokens = 192
 
@@ -140,6 +148,8 @@ class EdgeCasesTest(unittest.TestCase):
         b = torch.ones(total_tokens, sz).cuda().to(torch.bfloat16)
         c = torch.ones(4, sz, sz).cuda().to(torch.bfloat16)
         batch_sizes = torch.tensor([0, 128, 0, 64]).to(torch.long)
+        if gpu_batch_sizes:
+            batch_sizes = batch_sizes.cuda()
 
         ops.backend.gmm(a, b, batch_sizes, trans_a=True, c=c)
         self.assertTrue((c[0] == 0).all())


### PR DESCRIPTION
This is a follow-up to #14.

The current implementation always expects the batch sizes to be on the CPU. If they are actually computed on the GPU (as happens in MoE training runs), this implies a GPU<->CPU synchronization point to fetch the batch sizes to the CPU, and then immediately send them back to the GPU in a slightly different format.

This PR gets rid of this roundtrip when it is possible (e.g. when using CUTLASS) by using a simple single-threadblock kernel that converts a list of batch sizes to the kernel arguments CUTLASS expects. I suppose 1024 experts (the practical limit on the number of threads in one threadblock) ought to be enough for everybody. :) If not, I can re-write it with a slightly less efficient kernel with multiple threadblocks.

Here's a slightly contrived synthetic example that illustrates the cost of the roundtrip (if the GEMMs and the context length are large enough, the cost is negligible):
```python
import torch
import grouped_gemm as gg


use_cpu_batch_sizes = True


if __name__ == '__main__':
    # GRIN-MoE sizes.
    M = 1024
    K = 4096
    N = 6400
    E = 8

    torch.manual_seed(0)

    x = torch.rand(M, K, dtype=torch.bfloat16, device='cuda')
    w = torch.rand(E, K, N, dtype=torch.bfloat16, device='cuda')

    x.requires_grad_(True)
    w.requires_grad_(True)

    batch_sizes = torch.tensor([M//E]*E, device='cuda')

    with torch.profiler.profile(activities=[
        torch.profiler.ProfilerActivity.CPU,
        torch.profiler.ProfilerActivity.CUDA
    ]) as prof:
        for _ in range(30):
            if use_cpu_batch_sizes:
                out = gg.ops.gmm(x, w, batch_sizes.cpu())
            else:
                out = gg.ops.gmm(x, w, batch_sizes)
            grad = out.sum().backward()

    torch.cuda.synchronize()
    prof.export_chrome_trace(f'gmm_trace.json')
```

|   | Total kernel runtime (not including the first warmup kernels), ms | Perfetto trace |
| ------------- | ------------- | -------- |
| With CPU<->GPU sync |  **68** | [a100_with_cpu_sync.json](https://github.com/user-attachments/files/17383555/a100_with_cpu_sync.json) |
| Without CPU<->GPU sync | **60** | [a100_no_cpu_sync.json](https://github.com/user-attachments/files/17383559/a100_no_cpu_sync.json) |

In this toy example a CPU<->GPU sync is mostly a minor annoyance, but in serious training runs that overlap compute and comms in ZeRO3-like fashion, this sync can be devastating because we can't schedule a NCCL collective to prefetch the parameters for the next layer until we are done with the current one. We saw throughput hits as large as 60%, but unfortunately, it's hard to come up with a minimal example to reproduce this.

[The CUTLASS issue](https://github.com/NVIDIA/cutlass/pull/1593) with `k=0` grouped GEMMs is still not resolved, so I had to resort to ugly hacks on the GPU side as well. Hopefully I can remove them someday. :)