### PR TITLE
Update pyproject.toml with tighter torch pin

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 recursive-include csrc *.h
 recursive-include csrc *.cu
+recursive-include csrc *.cuh
 
 recursive-include third_party/cutlass/include *.h
 recursive-include third_party/cutlass/include *.hpp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 # build requirements
 [build-system]
-requires = ["setuptools < 70.0.0", "packaging >= 21.0.0", "torch>=2.4.0,<3.0"]
+requires = ["setuptools < 81.0.0", "packaging >= 21.0.0", "torch>=2.4.0,<2.7"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ extra_deps['all'] = set(dep for deps in extra_deps.values() for dep in deps)
 
 setup(
     name="grouped_gemm",
-    version="0.1.6",
+    version="0.2.0",
     author="Trevor Gale",
     author_email="tgale@stanford.edu",
     description="Grouped GEMM",


### PR DESCRIPTION
The torch version pin in pyproject.toml allowed <3, which means that with torch 2.7, you may get errors like `ImportError: /usr/lib/python3/dist-packages/grouped_gemm_backend.cpython-312-x86_64-linux-gnu.so: undefined symbol: _ZN3c106detail23torchInternalAssertFailEPKcS2_jS2_RKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE` if you don't install with `--no-build-isolation`.

I believe this broke with 2.7 because the default for `torch.compiled_with_cxx11_abi()` changed to `True`, so if you have 2.6 (default cxx11 false) installed in your runtime and install grouped-gemm, you get the above error.

This PR fixes that by more tightly pinning torch version, and then we can do an upgrade to 2.7 in a new version.

Tested with
`pip install git+https://github.com/dakinggg/grouped_gemm@patch-1 --no-cache`
```
In [1]: import grouped_gemm
In [2]:
```

Along for the ride, raised setuptools pin to something more recent, and adds cuh files to the manifest so the package builds properly.

Also updates version to 0.2.0 since lowering a version is kind of a breaking change if you were already on 2.7.
